### PR TITLE
Revert "Bump python from 3.9-slim to 3.10.0-slim"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.0-slim
+FROM python:3.9-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
Reverts tomasbedrich/xcontest-rss-monitor#70