### PR TITLE
Use MarkdownV2 for posted flights, link to pilot detail page

### DIFF
--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -1,5 +1,6 @@
 import asyncio
 import datetime
+import html
 import json
 import logging
 from asyncio import Task
@@ -272,7 +273,8 @@ async def watch():
                 for chat_id in pilot_data.chat_ids:
                     log.debug(f"About to post {flight} to {chat_id=}")
                     try:
-                        await bot.send_message(chat_id, f"{flight.title}\n{flight.link}")
+                        flight_title = html.escape(flight.title)
+                        await bot.send_message(chat_id, f'<a href="{flight.link}">{flight_title}</a> [<a href="{flight.pilot.url}">{flight.pilot.username}</a>]', parse_mode="HTML")
                     except BotBlocked:
                         to_unregister.append((flight.pilot, chat_id))
                         continue


### PR DESCRIPTION
I adjusted the formatting of messages slightly -- old:

<blockquote><img width="266" alt="old" src="https://github.com/tomasbedrich/xcontest-rss-monitor/assets/49209/4fd35c1d-6ae4-4401-8984-7b4fefe15bf9"></blockquote>

New:

<blockquote><img width="271" alt="new" src="https://github.com/tomasbedrich/xcontest-rss-monitor/assets/49209/024cd734-19ca-4a75-89a3-162fdedf23c7"></blockquote>

I think the only thing lost is the start time of the flight (embedded in the URI), but that was in UTC anyway so not all that useful.  In exchange we get a more direct link to the pilot's profile page and we save some pixels :)