### PR TITLE
Revert "Bump python from 3.12.0-slim to 3.12.1-slim"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.1-slim
+FROM python:3.12.0-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
Reverts tomasbedrich/xcontest-rss-monitor#194